### PR TITLE
Show part and chapter in navigation pane

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -40,16 +40,17 @@ var LatexParser = (function () {
 var StructureParser = (function (_super) {
     __extends(StructureParser, _super);
     function StructureParser() {
-        _super.call(this, /\\(sub)*section\{([^}]+)\}/g);
+        _super.call(this, /\\(part|chapter|(sub)*section)\{([^}]+)\}/g);
     }
     return StructureParser;
 }(LatexParser));
 exports.StructureParser = StructureParser;
 var levels = {
     '\\part{': 1,
-    '\\section{': 2,
-    '\\subsection{': 3,
-    '\\subsubsection{': 4
+    '\\chapter{': 2,
+    '\\section{': 3,
+    '\\subsection{': 4,
+    '\\subsubsection{': 5
 };
 var TodoParser = (function (_super) {
     __extends(TodoParser, _super);


### PR DESCRIPTION
This fixes the parser such that parts (`\part`) chapters (`\chapter`) are also shown in the navigation pane.