### PR TITLE
Hide menu items in non-latex environment.

### DIFF
--- a/menus/latex-friend.cson
+++ b/menus/latex-friend.cson
@@ -1,5 +1,5 @@
 'context-menu':
-  'atom-text-editor': [
+  'atom-text-editor[data-grammar*="text tex"]': [
     {
       'label': 'Sync PDF'
       'command': 'latex-friend:syncpdf'


### PR DESCRIPTION
Hide latex-related menu items in non-latex environment, as the menu items are not working in other source files except for tex files.
